### PR TITLE
Remove session data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-- '5.5'
+- '5.6'
 
 script: echo "We don't have tests yet :("
 

--- a/onepay/controllers/front/commit.php
+++ b/onepay/controllers/front/commit.php
@@ -44,7 +44,6 @@ class OnepayCommitModuleFrontController extends ModuleFrontController
                 $cart = new Cart((int)$cart_id);
                 $customer = new Customer((int)$cart->id_customer);
                 if (Context::getContext()->customer->secure_key == null) {
-                    $customer = new Customer((int)$cart->id_customer);
                     Context::getContext()->customer =  $customer;
                     $secure_key = $customer->secure_key;
                 } else {
@@ -67,7 +66,6 @@ class OnepayCommitModuleFrontController extends ModuleFrontController
                     $message = json_encode($full_response);
 
                     $module_name = $this->module->displayName;
-                    $currency_id = (int)Context::getContext()->currency->id;
                     $this->module->validateOrder($cart_id, $payment_status, $cart->getOrderTotal(), $module_name, $message, array(), null, false, $secure_key);
 
                     $order_id = Order::getOrderByCartId((int)$cart->id);

--- a/onepay/controllers/front/commit.php
+++ b/onepay/controllers/front/commit.php
@@ -37,10 +37,19 @@ class OnepayCommitModuleFrontController extends ModuleFrontController
 
                 $transactionCommitResponse = Transaction::commit($occ, $externalUniqueNumber, $options);
 
-                $cart_id=Context::getContext()->cart->id;
-                $secure_key=Context::getContext()->customer->secure_key;
+                $cart_id = Tools::getValue('cart_id');
+                if($cart_id == null) {
+                    $cart_id=Context::getContext()->cart->id;
+                }
                 $cart = new Cart((int)$cart_id);
                 $customer = new Customer((int)$cart->id_customer);
+                if (Context::getContext()->customer->secure_key == null) {
+                    $customer = new Customer((int)$cart->id_customer);
+                    Context::getContext()->customer =  $customer;
+                    $secure_key = $customer->secure_key;
+                } else {
+                    $secure_key = Context::getContext()->customer->secure_key;
+                }
 
                 $full_response = [];
                 $full_response['occ'] = $transactionCommitResponse->getOcc();
@@ -59,7 +68,7 @@ class OnepayCommitModuleFrontController extends ModuleFrontController
 
                     $module_name = $this->module->displayName;
                     $currency_id = (int)Context::getContext()->currency->id;
-                    $this->module->validateOrder($cart_id, $payment_status, $cart->getOrderTotal(), $module_name, $message, array(), $currency_id, false, $secure_key);
+                    $this->module->validateOrder($cart_id, $payment_status, $cart->getOrderTotal(), $module_name, $message, array(), null, false, $secure_key);
 
                     $order_id = Order::getOrderByCartId((int)$cart->id);
                     if ($order_id && ($secure_key == $customer->secure_key)) {

--- a/onepay/controllers/front/transaction.php
+++ b/onepay/controllers/front/transaction.php
@@ -34,6 +34,8 @@ class OnepayTransactionModuleFrontController extends ModuleFrontController
 
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 
+            $ps_cart = $this->context->cart;
+
             $channel = isset($_POST['channel']) ? $_POST['channel'] : null;
             $endpoint = Configuration::get('ONEPAY_ENDPOINT', null);
             $apiKey = Configuration::get('ONEPAY_APIKEY', null);
@@ -43,9 +45,7 @@ class OnepayTransactionModuleFrontController extends ModuleFrontController
             OnepayBase::setApiKey($apiKey);
             OnepayBase::setSharedSecret($sharedSecret);
             OnepayBase::setCurrentIntegrationType($endpoint);
-            OnepayBase::setCallbackUrl($callbackUrl);
-            
-            $ps_cart = $this->context->cart;
+            OnepayBase::setCallbackUrl($callbackUrl . '&cart_id=' . $ps_cart->id);
 
             $ps_products = $ps_cart->getProducts(true);
 
@@ -85,7 +85,7 @@ class OnepayTransactionModuleFrontController extends ModuleFrontController
                     'issuedAt' => $transaction->getIssuedAt(),
                     'signature' => $transaction->getSignature(),
                     'amount' => $carro->getTotal(),
-                    'callbackUrl' => $callbackUrl
+                    'callbackUrl' => ($callbackUrl . '&cart_id=' . $ps_cart->id )
                 ]));
 
             } catch (TransbankException $transbank_exception) {


### PR DESCRIPTION
In the mobile case the user can use a navigator different of the default, in this case, when the onepay app returns to the web invoke the default browser that does not have the session data, displaying an error.
Now the method commit search the cart id from url in the mobile case, removing the error when using another browser.